### PR TITLE
Remove wifi wizard keyboard shortcut, not needed now

### DIFF
--- a/lib/xebow/keys.ex
+++ b/lib/xebow/keys.ex
@@ -59,7 +59,7 @@ defmodule Xebow.Keys do
       k002: AFK.Keycode.MFA.new({__MODULE__, :previous_animation, []}),
       k003: AFK.Keycode.Transparent.new(),
       k004: AFK.Keycode.Transparent.new(),
-      k005: AFK.Keycode.MFA.new({__MODULE__, :start_wifi_wizard, []}),
+      k005: AFK.Keycode.Transparent.new(),
       k006: AFK.Keycode.Transparent.new(),
       k007: AFK.Keycode.Transparent.new(),
       k008: AFK.Keycode.Transparent.new(),


### PR DESCRIPTION
We are no longer enabling the wifi wizard by default because there is no good use case right now for why it's needed now that usb connectivity works.  This PR removes the keyboard shortcut that explicitly tries to enables it.