### PR TITLE
Rename hardware target

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Xebow.MixProject do
 
   @app :xebow
   @version "0.1.0"
-  @all_targets [:xebow_rpi0]
+  @all_targets [:keybow]
 
   def project do
     [
@@ -56,7 +56,7 @@ defmodule Xebow.MixProject do
 
       # Dependencies for specific targets
       {:xebow_rpi0,
-       github: "doughsay/xebow_rpi0", ref: "v1.10.2+xebow.2", runtime: false, targets: :xebow_rpi0}
+       github: "doughsay/xebow_rpi0", ref: "v1.10.2+xebow.2", runtime: false, targets: :keybow}
     ]
   end
 


### PR DESCRIPTION
What do you think about renaming the hardware target to:
1. `keybow`
2. `rpi0`

My thought behind this is that the [Nerves target](https://hexdocs.pm/nerves/targets.html#content) is the _hardware_ that the firmware is designed to run on. Since Xebow is a firmware modification to the Keybow and does not modify the hardware, I think the target should be named after the hardware.

That being said, there are two major components that could be considered in regards to Xebow's target:
1. Keybow, which is the entire hardware platform. This includes the RPi0, keys, LEDs, etc.
2. The RPi0, which is just the embedded processor and doesn't include the peripherals.

Due to this I lean towards `keybow` as the target, but I could see either being valid. One litmus test could be: "Can Xebow run effectively on a Raspberry Pi without the Keybow perpherials"? I believe the answer is no, which again, draws me more towards `keybow` rather than `rpi0`.

Thoughts?